### PR TITLE
Re style

### DIFF
--- a/src/routes/BlockDisplay.svelte
+++ b/src/routes/BlockDisplay.svelte
@@ -40,13 +40,11 @@
 <style>
     .keywords_holder {
         display: flex;
-        flex-direction: column;
+        flex-direction: row;
         flex-wrap: wrap;
         align-items: center;
         justify-content: space-evenly;
         border: 1px solid black;
-        padding: 10px;
-        width: 30%;
-        max-height: 75vh;
+        padding: 5px;
     }
 </style>

--- a/src/routes/CurrentQuery.svelte
+++ b/src/routes/CurrentQuery.svelte
@@ -17,5 +17,6 @@
         flex-direction: column;
         justify-content: center;
         align-self: center;
+        width: 100%;
     }
 </style>

--- a/src/routes/DBSelection.svelte
+++ b/src/routes/DBSelection.svelte
@@ -70,9 +70,10 @@
     }
 
     input[type="file"]::file-selector-button {
-        background: #52b788;
+        background: #00A6FB;
         border: none;
         border-radius: 5px;
+        color: #eee;
         padding: 5px;
     }
     input[type="file"]::file-selector-button:hover {
@@ -107,8 +108,9 @@
     }
 
     .selected_db {
-        background-color: #52b788;
+        background-color: #00A6FB;
         border-radius: 5px;
+        color: #eee;
         padding: 5px;
     }
 

--- a/src/routes/DBSelection.svelte
+++ b/src/routes/DBSelection.svelte
@@ -47,6 +47,7 @@
     }
 
     input[type="file"] {
+        background-color: #fff;
         border: 1px solid #000;
         border-radius: 10px;
         color: #444;
@@ -72,6 +73,10 @@
         gap: 10px;
         justify-content: center;
         align-items: center;
+    }
+
+    .input_container:hover {
+        background-color: #eee;
     }
 
     .input_title {

--- a/src/routes/DBSelection.svelte
+++ b/src/routes/DBSelection.svelte
@@ -3,6 +3,15 @@
     import { getDbBlocks } from "$lib/database/dbUtils";
 
     let input: HTMLInputElement;
+    let isOnDragArea = false;
+
+    $: active_class = isOnDragArea ? "input_active" : "";
+
+    const handleDrop = (event: DragEvent) => {
+        if (!event || !event.dataTransfer) return;
+        input.files = event.dataTransfer.files;
+        handleUpload();
+    };
 
     const handleUpload = () => {
         if (!input.files) return;
@@ -28,7 +37,13 @@
                 Using default DB
             {/if}
         </div>
-        <label class="input_container">
+        <label
+            class="input_container {active_class}"
+            on:dragenter={() => (isOnDragArea = true)}
+            on:dragleave={() => (isOnDragArea = false)}
+            on:dragover|preventDefault
+            on:drop|preventDefault={handleDrop}
+        >
             <span class="input_title">Drop a SQLite DB here!</span>
             or
             <input
@@ -75,7 +90,8 @@
         align-items: center;
     }
 
-    .input_container:hover {
+    .input_container:hover,
+    .input_active {
         background-color: #eee;
     }
 

--- a/src/routes/DBSelection.svelte
+++ b/src/routes/DBSelection.svelte
@@ -18,18 +18,83 @@
     };
 </script>
 
-<h2>Use the default DB or upload your own</h2>
-{#if input?.files && input?.files[0]}
-    <p>Using user DB</p>
-{:else}
-    <p>Using default DB</p>
-{/if}
-<input
-    type="file"
-    accept=".sqlite"
-    bind:this={input}
-    on:change={handleUpload}
-/>
+<div class="selection_container">
+    <h2>Use the default DB or upload your own</h2>
+    <div class="row_container">
+        <div class="selected_db">
+            {#if input?.files && input?.files[0]}
+                Using user DB
+            {:else}
+                Using default DB
+            {/if}
+        </div>
+        <label class="input_container">
+            <span class="input_title">Drop a SQLite DB here!</span>
+            or
+            <input
+                type="file"
+                accept=".sqlite"
+                bind:this={input}
+                on:change={handleUpload}
+            />
+        </label>
+    </div>
+</div>
 
 <style>
+    h2 {
+        margin: 5px;
+    }
+
+    input[type="file"] {
+        border: 1px solid #000;
+        border-radius: 10px;
+        color: #444;
+        padding: 5px;
+    }
+
+    input[type="file"]::file-selector-button {
+        background: #52b788;
+        border: none;
+        border-radius: 5px;
+        padding: 5px;
+    }
+    input[type="file"]::file-selector-button:hover {
+        opacity: 0.8;
+    }
+
+    .input_container {
+        display: flex;
+        flex-direction: column;
+        padding: 20px;
+        border: 2px dashed #081c15;
+        border-radius: 10px;
+        gap: 10px;
+        justify-content: center;
+        align-items: center;
+    }
+
+    .input_title {
+        font-weight: bold;
+    }
+
+    .selection_container {
+        display: flex;
+        flex-flow: column;
+        margin: 10px;
+        padding: 5px;
+    }
+
+    .selected_db {
+        background-color: #52b788;
+        border-radius: 5px;
+        padding: 5px;
+    }
+
+    .row_container {
+        align-items: center;
+        display: flex;
+        flex-direction: row;
+        justify-content: space-around;
+    }
 </style>

--- a/src/routes/QueryDisplay.svelte
+++ b/src/routes/QueryDisplay.svelte
@@ -16,30 +16,62 @@
     };
 </script>
 
-<div
-    role="textbox"
-    class="queries_holder"
-    tabindex="-1"
-    on:dragover|preventDefault={handleDragOver}
-    on:drop|preventDefault={handleDrop}
->
-    {#if queryElements.length > 0}
-        {#each queryElements as element}
-            <Block keyword={element} />
-        {/each}
-    {:else}
-        <p>Drop some keywords here to begin</p>
-    {/if}
+<div class="container">
+    <div
+        role="textbox"
+        class="query_holder"
+        tabindex="-1"
+        on:dragover|preventDefault={handleDragOver}
+        on:drop|preventDefault={handleDrop}
+    >
+        {#if queryElements.length > 0}
+            {#each queryElements as element}
+                <Block keyword={element} />
+            {/each}
+        {:else}
+            <p class="placeholder">Drop some keywords here to begin</p>
+        {/if}
+    </div>
+    <button on:click={() => (queryElements = [])}>RESET</button>
 </div>
-<button on:click={() => (queryElements = [])}>RESET</button>
 
 <style>
-    .queries_holder {
+    button {
+        all: unset;
+        background-color: #0582ca;
+        border-radius: 5px;
+        color: #eee;
+        cursor: pointer;
+        padding: 10px;
+    }
+
+    button:hover {
+        opacity: 0.8;
+    }
+
+    .container {
+        align-items: center;
         display: flex;
         flex-direction: row;
-        align-items: baseline;
-        justify-content: flex-start;
-        border: 1px solid black;
+        gap: 10px;
         padding: 10px;
+        width: 100%;
+    }
+
+    .placeholder {
+        color: #eee;
+        font-family: monospace;
+    }
+
+    .query_holder {
+        align-items: baseline;
+        background-color: #003554;
+        border: 1px solid black;
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        justify-content: flex-start;
+        padding: 10px;
+        width: 80%;
     }
 </style>

--- a/src/routes/QueryDisplay.svelte
+++ b/src/routes/QueryDisplay.svelte
@@ -29,7 +29,7 @@
                 <Block keyword={element} />
             {/each}
         {:else}
-            <p class="placeholder">Drop some keywords here to begin</p>
+            <p class="placeholder">Drop some blocks here to begin</p>
         {/if}
     </div>
     <button on:click={() => (queryElements = [])}>RESET</button>
@@ -66,7 +66,7 @@
     .query_holder {
         align-items: baseline;
         background-color: #003554;
-        border: 1px solid black;
+        border-radius: 10px;
         display: flex;
         flex-direction: row;
         flex-wrap: wrap;

--- a/src/routes/QueryResult.svelte
+++ b/src/routes/QueryResult.svelte
@@ -4,19 +4,25 @@
     import type { BlockContent, QueryResult } from "$lib/appTypes";
 
     export let queryElements: BlockContent[];
+    let queryString = "";
     let queryResult: QueryResult | undefined;
 
     const runQuery = async () => {
         if (!$dbFile || queryElements.length == 0) return;
-        let queryString = queryElements.map((e) => e.name).join(" ");
+        queryString = queryElements.map((e) => e.name).join(" ");
         queryResult = await query($dbFile, queryString);
     };
+
+    const handleReset = () => {
+        queryResult = undefined;
+        queryString = "";
+    }
 </script>
 
 <div class="container">
     <div class="query_controls">
         <button class="button_run" on:click={runQuery}>Run Query</button>
-        <button class="button_reset" on:click={() => (queryResult = undefined)}>
+        <button class="button_reset" on:click={handleReset}>
             Reset Result</button
         >
     </div>
@@ -24,6 +30,9 @@
         <p class="placeholder">Run a query to display results here</p>
     {:else}
         <table>
+            <caption>
+                {queryString}
+            </caption>
             <thead>
                 {#each queryResult.columns as column}
                     <th>{column}</th>
@@ -55,6 +64,31 @@
         opacity: 0.8;
     }
 
+    caption {
+        font-style: italic;
+        color: #999;
+        padding: 5px;
+    }
+
+    table {
+        border-bottom: 2px solid #000;
+        border-top: 2px solid #000;
+        border-collapse: collapse;
+        table-layout: fixed;
+        text-align: center;
+        width: 100%;
+    }
+
+    th {
+        background-color: #0582CA;
+        border-bottom: 2px solid #000;
+        color:#fff;
+    }
+
+    th, td {
+        padding: 5px;
+    }
+
     .button_run {
         background-color: #00a6fb;
     }
@@ -79,5 +113,6 @@
         flex-direction: row;
         justify-content: space-around;
         gap: 10px;
+        margin: 10px;
     }
 </style>

--- a/src/routes/QueryResult.svelte
+++ b/src/routes/QueryResult.svelte
@@ -29,25 +29,27 @@
     {#if !queryResult}
         <p class="placeholder">Run a query to display results here</p>
     {:else}
-        <table>
-            <caption>
-                {queryString}
-            </caption>
-            <thead>
-                {#each queryResult.columns as column}
+        <div class="overflow_handled">
+            <table>
+                <caption>
+                    {queryString}
+                </caption>
+                <thead>
+                    {#each queryResult.columns as column}
                     <th>{column}</th>
-                {/each}
-            </thead>
-            <tbody>
-                {#each queryResult.rows as row}
+                    {/each}
+                </thead>
+                <tbody>
+                    {#each queryResult.rows as row}
                     <tr>
                         {#each row as cell}
-                            <td>{cell}</td>
+                        <td>{cell}</td>
                         {/each}
                     </tr>
-                {/each}
-            </tbody>
-        </table>
+                    {/each}
+                </tbody>
+            </table>
+        </div>
     {/if}
 </div>
 
@@ -76,7 +78,6 @@
         border-collapse: collapse;
         table-layout: fixed;
         text-align: center;
-        width: 100%;
     }
 
     th {
@@ -102,6 +103,11 @@
         display: flex;
         flex-direction: column;
         padding: 10px;
+    }
+
+    .overflow_handled {
+        overflow-x: auto;
+        width: 100%;
     }
 
     .placeholder {

--- a/src/routes/QueryResult.svelte
+++ b/src/routes/QueryResult.svelte
@@ -90,6 +90,10 @@
         padding: 5px;
     }
 
+    tr:hover {
+        background-color: #00a6fb44;
+    }
+
     .button_run {
         background-color: #00a6fb;
     }
@@ -106,6 +110,8 @@
     }
 
     .overflow_handled {
+        display: flex;
+        justify-content: center;
         overflow-x: auto;
         width: 100%;
     }

--- a/src/routes/QueryResult.svelte
+++ b/src/routes/QueryResult.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { dbFile } from "$lib/stores/dbStore";
-    import type { BlockContent, QueryResult } from "$lib/appTypes";
     import query from "$lib/database/connection";
+    import type { BlockContent, QueryResult } from "$lib/appTypes";
 
     export let queryElements: BlockContent[];
     let queryResult: QueryResult | undefined;
@@ -13,11 +13,15 @@
     };
 </script>
 
-<div>
-    <button on:click={runQuery}>Run Query</button>
-    <button on:click={() => queryResult = undefined}>Reset Result</button>
+<div class="container">
+    <div class="query_controls">
+        <button class="button_run" on:click={runQuery}>Run Query</button>
+        <button class="button_reset" on:click={() => (queryResult = undefined)}>
+            Reset Result</button
+        >
+    </div>
     {#if !queryResult}
-        <p>Run a query to display results</p>
+        <p class="placeholder">Run a query to display results here</p>
     {:else}
         <table>
             <thead>
@@ -37,3 +41,43 @@
         </table>
     {/if}
 </div>
+
+<style>
+    button {
+        all: unset;
+        border-radius: 5px;
+        color: #eee;
+        cursor: pointer;
+        padding: 10px;
+    }
+
+    button:hover {
+        opacity: 0.8;
+    }
+
+    .button_run {
+        background-color: #00a6fb;
+    }
+
+    .button_reset {
+        background-color: #0582ca;
+    }
+
+    .container {
+        align-items: center;
+        display: flex;
+        flex-direction: column;
+        padding: 10px;
+    }
+
+    .placeholder {
+        font-weight: bold;
+    }
+
+    .query_controls {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-around;
+        gap: 10px;
+    }
+</style>


### PR DESCRIPTION
A basic and light styling of the overall app has been introduced. This includes the differentiation of one color palette for the blocks [(for blocks)](https://coolors.co/palette/d8f3dc-b7e4c7-95d5b2-74c69d-52b788-40916c-2d6a4f-1b4332-081c15) and another one [(for everything else)](https://coolors.co/palette/00a6fb-0582ca-006494-003554-051923) for the base UI elements.

Some design decisions, like moving DB Selection for a modal or results formatting will be moved to their own issues due to their scope. This is only a starting point, expect a more profound revamp once a clearer picture of this project is visible after it moves beyond this initial state.