### PR TITLE
Tab navigation to select Block groups

### DIFF
--- a/src/lib/appTypes.ts
+++ b/src/lib/appTypes.ts
@@ -3,6 +3,7 @@ export type Dictionary<T> = { [key: string]: T };
 export type BlockContent = {
     name: string;
     type: string;
+    columns?: BlockContent[];
 };
 
 export type QueryResult = {

--- a/src/lib/components/Block.svelte
+++ b/src/lib/components/Block.svelte
@@ -4,9 +4,10 @@
     export let content: BlockContent;
 
     const colors: Dictionary<string> = {
-        keyword: '#57cc99',
-        column: '#80ED99',
-        table: '#38A3A5',
+        keyword: '#78C6A3',
+        column: '#67B99A',
+        table: '#14746F',
+        symbol: '#99E2B4',
     };
 
     const handleDrag = (event: DragEvent) => {

--- a/src/lib/components/Block.svelte
+++ b/src/lib/components/Block.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import type { BlockContent, Dictionary } from "$lib/appTypes";
 
-    export let keyword: BlockContent;
+    export let content: BlockContent;
 
     const colors: Dictionary<string> = {
         keyword: '#57cc99',
@@ -11,20 +11,20 @@
 
     const handleDrag = (event: DragEvent) => {
         if (!event || !event.dataTransfer) return;
-        event.dataTransfer.setData("text/plain", JSON.stringify(keyword));
+        event.dataTransfer.setData("text/plain", JSON.stringify(content));
         event.dataTransfer.dropEffect = "copy";
     };
 </script>
 
 <div
     class="block"
-    style="--block-color: {colors[keyword.type]}"
+    style="--block-color: {colors[content.type]}"
     role="textbox"
     tabindex="-1"
     draggable="true"
     on:dragstart={handleDrag}
 >
-    {keyword.name}
+    {content.name}
 </div>
 
 <style>

--- a/src/lib/keywords/keywords.ts
+++ b/src/lib/keywords/keywords.ts
@@ -11,8 +11,4 @@ export const keywords = [
         name: "WHERE",
         type: "keyword",
     },
-    {
-        name: "*",
-        type: "column",
-    },
 ];

--- a/src/lib/keywords/keywords.ts
+++ b/src/lib/keywords/keywords.ts
@@ -11,4 +11,20 @@ export const keywords = [
         name: "WHERE",
         type: "keyword",
     },
+    {
+        name: "LIMIT",
+        type: "keyword",
+    },
+    {
+        name: "AND",
+        type: "keyword",
+    },
+    {
+        name: "OR",
+        type: "keyword",
+    },
+    {
+        name: "NOT",
+        type: "keyword",
+    },
 ];

--- a/src/lib/keywords/symbols.ts
+++ b/src/lib/keywords/symbols.ts
@@ -1,0 +1,10 @@
+export const symbols = [
+    {
+        name: "*",
+        type: "column",
+    },
+    {
+        name: "0",
+        type: "symbol",
+    }
+];

--- a/src/lib/keywords/symbols.ts
+++ b/src/lib/keywords/symbols.ts
@@ -6,5 +6,53 @@ export const symbols = [
     {
         name: "0",
         type: "symbol",
-    }
+    },
+    {
+        name: "1",
+        type: "symbol",
+    },
+    {
+        name: "2",
+        type: "symbol",
+    },
+    {
+        name: "3",
+        type: "symbol",
+    },
+    {
+        name: "4",
+        type: "symbol",
+    },
+    {
+        name: "5",
+        type: "symbol",
+    },
+    {
+        name: "6",
+        type: "symbol",
+    },
+    {
+        name: "7",
+        type: "symbol",
+    },
+    {
+        name: "8",
+        type: "symbol",
+    },
+    {
+        name: "9",
+        type: "symbol",
+    },
+    {
+        name: "=",
+        type: "symbol",
+    },
+    {
+        name: "<",
+        type: "symbol",
+    },
+    {
+        name: ">",
+        type: "symbol",
+    },
 ];

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,6 +7,7 @@
     import DbSelection from "./DBSelection.svelte";
     import BlockDisplay from "./BlockDisplay.svelte";
     import CurrentQuery from "./CurrentQuery.svelte";
+    import BlockSelection from "./BlockSelection.svelte";
 
     onMount(async () => {
         const res = await fetch("/simplefolks.sqlite");
@@ -19,7 +20,7 @@
     <h1>Welcome to Block Query Language</h1>
     <div class="split_displays">
         <div class="display_side">
-            <BlockDisplay />
+            <BlockSelection />
         </div>
         <div class="display_side">
             <DbSelection />

--- a/src/routes/BlockDisplay.svelte
+++ b/src/routes/BlockDisplay.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
     import type { BlockContent } from "$lib/appTypes";
-    import { tablesAndColumns } from "$lib/stores/dbStore";
     import Block from "$lib/components/Block.svelte";
 
     export let blocks: BlockContent[];
@@ -9,15 +8,12 @@
 <div class="keywords_holder">
     {#each blocks as block}
         <Block content={block} />
-    {/each}
-    {#if $tablesAndColumns}
-        {#each $tablesAndColumns as table}
-            <Block content={table} />
-            {#each table.columns as column}
+        {#if block.columns}
+            {#each block.columns as column}
                 <Block content={column} />
             {/each}
-        {/each}
-    {/if}
+        {/if}
+    {/each}
 </div>
 
 <style>

--- a/src/routes/BlockDisplay.svelte
+++ b/src/routes/BlockDisplay.svelte
@@ -1,19 +1,20 @@
 <script lang="ts">
+    import type { BlockContent } from "$lib/appTypes";
     import { tablesAndColumns } from "$lib/stores/dbStore";
-
     import Block from "$lib/components/Block.svelte";
-    import { keywords } from "$lib/keywords/keywords";
+
+    export let blocks: BlockContent[];
 </script>
 
 <div class="keywords_holder">
-    {#each keywords as keyword}
-        <Block {keyword} />
+    {#each blocks as block}
+        <Block content={block} />
     {/each}
     {#if $tablesAndColumns}
         {#each $tablesAndColumns as table}
-            <Block keyword={table} />
+            <Block content={table} />
             {#each table.columns as column}
-                <Block keyword={column} />
+                <Block content={column} />
             {/each}
         {/each}
     {/if}

--- a/src/routes/BlockDisplay.svelte
+++ b/src/routes/BlockDisplay.svelte
@@ -18,12 +18,14 @@
 
 <style>
     .keywords_holder {
+        align-items: center;
+        border: 1px solid #051923;
+        border-radius: 10px;
         display: flex;
         flex-direction: row;
         flex-wrap: wrap;
-        align-items: center;
         justify-content: space-evenly;
-        border: 1px solid black;
         padding: 5px;
+        width: 95%;
     }
 </style>

--- a/src/routes/BlockSelection.svelte
+++ b/src/routes/BlockSelection.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+    import BlockDisplay from "./BlockDisplay.svelte";
+
+    import { tablesAndColumns } from "$lib/stores/dbStore";
+    import { keywords } from "$lib/keywords/keywords";
+</script>
+
+<div>
+    <BlockDisplay blocks={keywords} />
+</div>
+
+<style>
+</style>

--- a/src/routes/BlockSelection.svelte
+++ b/src/routes/BlockSelection.svelte
@@ -3,6 +3,7 @@
 
     import { tablesAndColumns } from "$lib/stores/dbStore";
     import { keywords } from "$lib/keywords/keywords";
+    import { symbols } from "$lib/keywords/symbols";
 
     enum BlockOptions {
         Keywords,
@@ -28,7 +29,7 @@
         } else if (blocksSelected === BlockOptions.TablesAndColumns) {
             blocksToDisplay = $tablesAndColumns;
         } else if (blocksSelected === BlockOptions.Symbols) {
-            console.log("No Symbols set yet");
+            blocksToDisplay = symbols;
         }
     };
 </script>

--- a/src/routes/BlockSelection.svelte
+++ b/src/routes/BlockSelection.svelte
@@ -4,22 +4,46 @@
     import { tablesAndColumns } from "$lib/stores/dbStore";
     import { keywords } from "$lib/keywords/keywords";
 
+    enum BlockOptions {
+        Keywords,
+        TablesAndColumns,
+        Symbols,
+    }
+
     let blocksToDisplay = keywords;
+    let blocksSelected = BlockOptions.Keywords;
 
-    const handleShowKeywords = () => {
-        blocksToDisplay = keywords;
+    $: {
+        if (
+            $tablesAndColumns &&
+            blocksSelected === BlockOptions.TablesAndColumns
+        )
+            blocksToDisplay = $tablesAndColumns;
     }
 
-    const handleShowTables = () => {
-        blocksToDisplay = $tablesAndColumns;
-    }
+    const handleSelection = (selection: BlockOptions) => {
+        blocksSelected = selection;
+        if (blocksSelected === BlockOptions.Keywords) {
+            blocksToDisplay = keywords;
+        } else if (blocksSelected === BlockOptions.TablesAndColumns) {
+            blocksToDisplay = $tablesAndColumns;
+        } else if (blocksSelected === BlockOptions.Symbols) {
+            console.log("No Symbols set yet");
+        }
+    };
 </script>
 
 <div class="container">
-    <div>
-        <button on:click={handleShowKeywords}>SQL Keywords</button>
-        <button on:click={handleShowTables}>Tables and Columns</button>
-        <button>Numbers and Symbols</button>
+    <div class="selection_controls">
+        <button on:click={() => handleSelection(BlockOptions.Keywords)}>
+            SQL Keywords
+        </button>
+        <button on:click={() => handleSelection(BlockOptions.TablesAndColumns)}>
+            Tables and Columns
+        </button>
+        <button on:click={() => handleSelection(BlockOptions.Symbols)}>
+            Numbers and Symbols
+        </button>
     </div>
     <BlockDisplay blocks={blocksToDisplay} />
 </div>

--- a/src/routes/BlockSelection.svelte
+++ b/src/routes/BlockSelection.svelte
@@ -36,13 +36,25 @@
 
 <div class="container">
     <div class="selection_controls">
-        <button on:click={() => handleSelection(BlockOptions.Keywords)}>
+        <button
+            class="option"
+            class:selected={blocksSelected === BlockOptions.Keywords}
+            on:click={() => handleSelection(BlockOptions.Keywords)}
+        >
             SQL Keywords
         </button>
-        <button on:click={() => handleSelection(BlockOptions.TablesAndColumns)}>
+        <button
+            class="option"
+            class:selected={blocksSelected === BlockOptions.TablesAndColumns}
+            on:click={() => handleSelection(BlockOptions.TablesAndColumns)}
+        >
             Tables and Columns
         </button>
-        <button on:click={() => handleSelection(BlockOptions.Symbols)}>
+        <button
+            class="option"
+            class:selected={blocksSelected === BlockOptions.Symbols}
+            on:click={() => handleSelection(BlockOptions.Symbols)}
+        >
             Numbers and Symbols
         </button>
     </div>
@@ -51,8 +63,34 @@
 
 <style>
     .container {
+        align-items: center;
         display: flex;
         flex-direction: column;
-        align-items: center;
+        gap: 10px;
+        width: 100%;
+    }
+
+    .option {
+        all: unset;
+        background-color: #00A6FB;
+        border-radius: 5px;
+        box-shadow: 3px 3px 1px #006494;
+        color: #eee;
+        cursor: pointer;
+        font-size: 0.9rem;
+        padding: 10px;
+    }
+
+    .selected {
+        background-color: #0582CA;
+        box-shadow: none;
+        transform: translateX(2px) translateY(2px);
+    }
+
+    .selection_controls {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        gap: 10px;
     }
 </style>

--- a/src/routes/BlockSelection.svelte
+++ b/src/routes/BlockSelection.svelte
@@ -3,11 +3,31 @@
 
     import { tablesAndColumns } from "$lib/stores/dbStore";
     import { keywords } from "$lib/keywords/keywords";
+
+    let blocksToDisplay = keywords;
+
+    const handleShowKeywords = () => {
+        blocksToDisplay = keywords;
+    }
+
+    const handleShowTables = () => {
+        blocksToDisplay = $tablesAndColumns;
+    }
 </script>
 
-<div>
-    <BlockDisplay blocks={keywords} />
+<div class="container">
+    <div>
+        <button on:click={handleShowKeywords}>SQL Keywords</button>
+        <button on:click={handleShowTables}>Tables and Columns</button>
+        <button>Numbers and Symbols</button>
+    </div>
+    <BlockDisplay blocks={blocksToDisplay} />
 </div>
 
 <style>
+    .container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
 </style>

--- a/src/routes/QueryDisplay.svelte
+++ b/src/routes/QueryDisplay.svelte
@@ -26,7 +26,7 @@
     >
         {#if queryElements.length > 0}
             {#each queryElements as element}
-                <Block keyword={element} />
+                <Block content={element} />
             {/each}
         {:else}
             <p class="placeholder">Drop some blocks here to begin</p>


### PR DESCRIPTION
Added buttons to act as selector for different groups of blocks: keywords, tables and columns and symbols. More work is needed to have the full suite of possible blocks, but it is less crowded now!