### PR TITLE
Stop block duplication and handle removal

### DIFF
--- a/src/lib/components/Block.svelte
+++ b/src/lib/components/Block.svelte
@@ -2,7 +2,8 @@
     import type { BlockContent, Dictionary } from "$lib/appTypes";
 
     export let content: BlockContent;
-    export let handleDrag: (event: DragEvent, content: BlockContent) => void;
+    export let handleDragStart: (event: DragEvent, content: BlockContent) => void;
+    export let handleDragEnd: (event: DragEvent, content: BlockContent) => void = () => {};
 
     const colors: Dictionary<string> = {
         keyword: '#78C6A3',
@@ -18,7 +19,8 @@
     role="textbox"
     tabindex="-1"
     draggable="true"
-    on:dragstart={(event) => handleDrag(event, content)}
+    on:dragstart={(event) => handleDragStart(event, content)}
+    on:dragend={(event) => handleDragEnd(event, content)}
 >
     {content.name}
 </div>

--- a/src/lib/components/Block.svelte
+++ b/src/lib/components/Block.svelte
@@ -2,18 +2,13 @@
     import type { BlockContent, Dictionary } from "$lib/appTypes";
 
     export let content: BlockContent;
+    export let handleDrag: (event: DragEvent, content: BlockContent) => void;
 
     const colors: Dictionary<string> = {
         keyword: '#78C6A3',
         column: '#67B99A',
         table: '#14746F',
         symbol: '#99E2B4',
-    };
-
-    const handleDrag = (event: DragEvent) => {
-        if (!event || !event.dataTransfer) return;
-        event.dataTransfer.setData("text/plain", JSON.stringify(content));
-        event.dataTransfer.dropEffect = "copy";
     };
 </script>
 
@@ -23,7 +18,7 @@
     role="textbox"
     tabindex="-1"
     draggable="true"
-    on:dragstart={handleDrag}
+    on:dragstart={(event) => handleDrag(event, content)}
 >
     {content.name}
 </div>

--- a/src/routes/BlockDisplay.svelte
+++ b/src/routes/BlockDisplay.svelte
@@ -4,7 +4,7 @@
 
     export let blocks: BlockContent[];
 
-    const handleDrag = (event: DragEvent, content: BlockContent) => {
+    const handleDragStart = (event: DragEvent, content: BlockContent) => {
         if (!event || !event.dataTransfer) return;
         event.dataTransfer.setData("text/plain", JSON.stringify(content));
         event.dataTransfer.dropEffect = "copy";
@@ -13,10 +13,10 @@
 
 <div class="keywords_holder">
     {#each blocks as block}
-        <Block content={block} {handleDrag} />
+        <Block content={block} {handleDragStart} />
         {#if block.columns}
             {#each block.columns as column}
-                <Block content={column} {handleDrag} />
+                <Block content={column} {handleDragStart} />
             {/each}
         {/if}
     {/each}

--- a/src/routes/BlockDisplay.svelte
+++ b/src/routes/BlockDisplay.svelte
@@ -3,14 +3,20 @@
     import Block from "$lib/components/Block.svelte";
 
     export let blocks: BlockContent[];
+
+    const handleDrag = (event: DragEvent, content: BlockContent) => {
+        if (!event || !event.dataTransfer) return;
+        event.dataTransfer.setData("text/plain", JSON.stringify(content));
+        event.dataTransfer.dropEffect = "copy";
+    };
 </script>
 
 <div class="keywords_holder">
     {#each blocks as block}
-        <Block content={block} />
+        <Block content={block} {handleDrag} />
         {#if block.columns}
             {#each block.columns as column}
-                <Block content={column} />
+                <Block content={column} {handleDrag} />
             {/each}
         {/if}
     {/each}

--- a/src/routes/QueryDisplay.svelte
+++ b/src/routes/QueryDisplay.svelte
@@ -19,7 +19,8 @@
             console.log("dropped outside");
             console.log(draggedElement);
         }
-    }
+        draggedElement = null;
+    };
 
     const handleDragOver = (event: DragEvent) => {
         if (!event || !event.dataTransfer) return;
@@ -28,18 +29,19 @@
 
     const handleDrop = (event: DragEvent) => {
         if (!event || !event.dataTransfer) return;
-        if (draggedElement && draggedElement.removed) {
-            console.log("This was originally here");
-            draggedElement = null;
-        }
+        if (draggedElement && draggedElement.removed) return;
         const data = JSON.parse(event.dataTransfer.getData("text/plain"));
         queryElements = [...queryElements, data];
     };
 
-    const handleLeave = (event: DragEvent) => {
+    const handleDragEnter = (event: DragEvent) => {
+        if (!event || !event.dataTransfer || !draggedElement) return;
+        draggedElement.removed = false;
+    };
+
+    const handleDragLeave = (event: DragEvent) => {
         if (!event || !event.dataTransfer || !draggedElement) return;
         draggedElement.removed = true;
-        console.log("block has left!", draggedElement);
     };
 </script>
 
@@ -50,7 +52,8 @@
         tabindex="-1"
         on:dragover|preventDefault={handleDragOver}
         on:drop|preventDefault={handleDrop}
-        on:dragleave|preventDefault={handleLeave}
+        on:dragenter|preventDefault={handleDragEnter}
+        on:dragleave|preventDefault={handleDragLeave}
     >
         {#if queryElements.length > 0}
             {#each queryElements as element}

--- a/src/routes/QueryDisplay.svelte
+++ b/src/routes/QueryDisplay.svelte
@@ -4,6 +4,12 @@
 
     export let queryElements: BlockContent[];
 
+    const handleDrag = (event: DragEvent, content: BlockContent) => {
+        if (!event || !event.dataTransfer) return;
+        event.dataTransfer.setData("text/plain", JSON.stringify(content));
+        event.dataTransfer.dropEffect = "copy";
+    }; 
+
     const handleDragOver = (event: DragEvent) => {
         if (!event || !event.dataTransfer) return;
         event.dataTransfer.dropEffect = "copy";
@@ -26,7 +32,7 @@
     >
         {#if queryElements.length > 0}
             {#each queryElements as element}
-                <Block content={element} />
+                <Block content={element} {handleDrag} />
             {/each}
         {:else}
             <p class="placeholder">Drop some blocks here to begin</p>

--- a/src/routes/QueryDisplay.svelte
+++ b/src/routes/QueryDisplay.svelte
@@ -3,7 +3,7 @@
     import Block from "$lib/components/Block.svelte";
 
     export let queryElements: BlockContent[];
-    let draggedElement: any;
+    let draggedElement: { content: BlockContent; removed: boolean } | null;
 
     const handleDragStart = (event: DragEvent, content: BlockContent) => {
         if (!event || !event.dataTransfer) return;
@@ -14,10 +14,10 @@
 
     const handleDragEnd = (event: DragEvent, content: BlockContent) => {
         if (!event || !event.dataTransfer) return;
-        console.log(event.dataTransfer);
         if (event.dataTransfer.dropEffect === "none") {
-            console.log("dropped outside");
-            console.log(draggedElement);
+            queryElements = queryElements.filter(
+                (element) => element !== content
+            );
         }
         draggedElement = null;
     };
@@ -29,7 +29,7 @@
 
     const handleDrop = (event: DragEvent) => {
         if (!event || !event.dataTransfer) return;
-        if (draggedElement && draggedElement.removed) return;
+        if (draggedElement) return;
         const data = JSON.parse(event.dataTransfer.getData("text/plain"));
         queryElements = [...queryElements, data];
     };


### PR DESCRIPTION
Blocks are no longer duplicated when dropped again in the query display. Blocks are also removed when dropped outside the query display.