### PR TITLE
Table column order

### DIFF
--- a/src/lib/database/dbUtils.ts
+++ b/src/lib/database/dbUtils.ts
@@ -4,6 +4,9 @@ import query from './connection';
 export const getDbBlocks = async (dbFile: ArrayBuffer) => {
     const blocks: BlockContent[] = [];
     const tables = await getTables(dbFile);
+    if (!tables) {
+        return blocks;
+    }
     for (let i = 0; i < tables?.length; i++) {
         blocks.push({
             id: `${tables[i]}-t-${Math.round(Math.random() * 1000)}`,
@@ -11,6 +14,9 @@ export const getDbBlocks = async (dbFile: ArrayBuffer) => {
             type: "table",
         });
         const columns = await getColumns(dbFile, tables[i]);
+        if (!columns) {
+            break;
+        }
         for (let j = 0; j < columns?.length; j++) {
             blocks.push({
                 id: `${columns[j]}-c-${Math.round(Math.random() * 1000)}`,
@@ -19,7 +25,6 @@ export const getDbBlocks = async (dbFile: ArrayBuffer) => {
             });
         }
     };
-    console.log(blocks);
     return blocks;
 }
 

--- a/src/lib/database/dbUtils.ts
+++ b/src/lib/database/dbUtils.ts
@@ -4,21 +4,21 @@ import query from './connection';
 export const getDbBlocks = async (dbFile: ArrayBuffer) => {
     const blocks: BlockContent[] = [];
     const tables = await getTables(dbFile);
-    tables?.forEach(async (table) => {
+    for (let i = 0; i < tables?.length; i++) {
         blocks.push({
-            id: `${table}-t-${Math.round(Math.random() * 1000)}`,
-            name: table,
+            id: `${tables[i]}-t-${Math.round(Math.random() * 1000)}`,
+            name: tables[i],
             type: "table",
         });
-        const columns = await getColumns(dbFile, table);
-        columns?.forEach((column) => {
+        const columns = await getColumns(dbFile, tables[i]);
+        for (let j = 0; j < columns?.length; j++) {
             blocks.push({
-                id: `${column}-c-${Math.round(Math.random() * 1000)}`,
-                name: column,
+                id: `${columns[j]}-c-${Math.round(Math.random() * 1000)}`,
+                name: columns[j],
                 type: "column",
-            })
-        });
-    });
+            });
+        }
+    };
     console.log(blocks);
     return blocks;
 }


### PR DESCRIPTION
Fixes #15 after svelte-dnd-action implementation. Table names are now followed by its own column names.