### PR TITLE
Stop blocks from QueryDisplay from being copied over to BlockDisplay

### DIFF
--- a/src/routes/BlockDisplay.svelte
+++ b/src/routes/BlockDisplay.svelte
@@ -11,8 +11,7 @@
 
     let ignoreDndEvents = false;
 
-    const handleConsider = (event: any) => {
-        console.log("BlockDisplay", event);
+    const handleConsider = (event: CustomEvent) => {
         const { trigger, id } = event.detail.info;
         if (trigger === TRIGGERS.DRAGGED_ENTERED) {
             ignoreDndEvents = true;
@@ -35,8 +34,7 @@
         }
     };
 
-    const handleFinalize = (event: any) => {
-        console.log("BlockDisplay", event);
+    const handleFinalize = (event: CustomEvent) => {
         if (!ignoreDndEvents) {
             blocks = event.detail.items;
         } else {

--- a/src/routes/BlockDisplay.svelte
+++ b/src/routes/BlockDisplay.svelte
@@ -12,8 +12,11 @@
     let ignoreDndEvents = false;
 
     const handleConsider = (event: any) => {
+        console.log("BlockDisplay", event);
         const { trigger, id } = event.detail.info;
-        if (trigger === TRIGGERS.DRAG_STARTED) {
+        if (trigger === TRIGGERS.DRAGGED_ENTERED) {
+            ignoreDndEvents = true;
+        } else if (trigger === TRIGGERS.DRAG_STARTED) {
             const index = blocks.findIndex((block) => block.id === id);
             const newId = `${id}_copy_${Math.round(Math.random() * 1000)}`;
             event.detail.items = event.detail.items.filter(
@@ -33,6 +36,7 @@
     };
 
     const handleFinalize = (event: any) => {
+        console.log("BlockDisplay", event);
         if (!ignoreDndEvents) {
             blocks = event.detail.items;
         } else {

--- a/src/routes/QueryDisplay.svelte
+++ b/src/routes/QueryDisplay.svelte
@@ -5,12 +5,12 @@
 
     export let queryElements: BlockContent[];
 
-    const handleConsider = (event: any) => {
+    const handleConsider = (event: CustomEvent) => {
         console.log(event);
         queryElements = event.detail.items;
     };
 
-    const handleFinalize = (event: any) => {
+    const handleFinalize = (event: CustomEvent) => {
         console.log(event);
         queryElements = event.detail.items;
         console.log(queryElements);
@@ -29,7 +29,7 @@
         on:consider={handleConsider}
         on:finalize={handleFinalize}
     >
-        {#each queryElements as element(element.id)}
+        {#each queryElements as element (element.id)}
             <Block content={element} />
         {/each}
     </div>


### PR DESCRIPTION
Blocks can no longer be dropped into BlockDisplay from QueryDisplay, avoiding another source of duplication of blocks in BlockDisplay. Closes #19 