### PR TITLE
Numbers blocks type

### DIFF
--- a/src/lib/components/Block.svelte
+++ b/src/lib/components/Block.svelte
@@ -8,6 +8,7 @@
         column: "#67B99A",
         table: "#14746F",
         symbol: "#99E2B4",
+        number: "#469D89",
     };
 </script>
 

--- a/src/lib/keywords/symbols.ts
+++ b/src/lib/keywords/symbols.ts
@@ -7,52 +7,52 @@ export const symbols = [
     {
         id: "GNBeh",
         name: "0",
-        type: "symbol",
+        type: "number",
     },
     {
         id: "MIwiC",
         name: "1",
-        type: "symbol",
+        type: "number",
     },
     {
         id: "gKj6m",
         name: "2",
-        type: "symbol",
+        type: "number",
     },
     {
         id: "cP51T",
         name: "3",
-        type: "symbol",
+        type: "number",
     },
     {
         id: "5KRez",
         name: "4",
-        type: "symbol",
+        type: "number",
     },
     {
         id: "zDnDj",
         name: "5",
-        type: "symbol",
+        type: "number",
     },
     {
         id: "pbBQJ",
         name: "6",
-        type: "symbol",
+        type: "number",
     },
     {
         id: "2nwTu",
         name: "7",
-        type: "symbol",
+        type: "number",
     },
     {
         id: "ZbmRY",
         name: "8",
-        type: "symbol",
+        type: "number",
     },
     {
         id: "yFqwv",
         name: "9",
-        type: "symbol",
+        type: "number",
     },
     {
         id: "qAXrk",

--- a/src/lib/utils/queryParser.test.ts
+++ b/src/lib/utils/queryParser.test.ts
@@ -43,7 +43,7 @@ const testArrayTwo = [
     },
     {
         name: "5",
-        type: "symbol",
+        type: "number",
     },
 ];
 
@@ -51,11 +51,11 @@ const testArrayThree = [
     ...testArrayTwo,
     {
         name: "0",
-        type: "symbol",
+        type: "number",
     },
     {
         name: "2",
-        type: "symbol",
+        type: "number",
     },
 ];
 
@@ -79,19 +79,19 @@ const testArrayFour = [
     },
     {
         name: "1",
-        type: "symbol",
+        type: "number",
     },
     {
         name: "2",
-        type: "symbol",
+        type: "number",
     },
     {
         name: "3",
-        type: "symbol",
+        type: "number",
     },
     {
         name: "4",
-        type: "symbol",
+        type: "number",
     },
     {
         name: "LIMIT",
@@ -99,7 +99,7 @@ const testArrayFour = [
     },
     {
         name: "3",
-        type: "symbol",
+        type: "number",
     },
 ]
 
@@ -120,5 +120,5 @@ test('Multiple symbols ', () => {
 });
 
 test('Multiple symbols and keywords mix', () => {
-    expect(queryParser(testArrayFour)).toBe('SELECT * FROM thistable WHERE acolumn <=1234 LIMIT 3');
+    expect(queryParser(testArrayFour)).toBe('SELECT * FROM thistable WHERE acolumn <= 1234 LIMIT 3');
 });

--- a/src/lib/utils/queryParser.ts
+++ b/src/lib/utils/queryParser.ts
@@ -1,15 +1,22 @@
 import type { BlockContent } from "$lib/appTypes";
 
+const T_SYMBOL = 'symbol';
+const T_NUMBER = 'number';
 /*
-Only block type that requires special handling is the symbol type
-It is currently easier to have each non-symbol append a space before
-and each symbol not to to avoid separating digits for example
+Block types that require special handling are symbol and numbers
+It is currently easier to have each non-symbol, non-number append a space before
+and the symbol or number not to to avoid separating digits or operators for example
 */
+
 const queryParser = (queryElements: BlockContent[]): string => {
     if (queryElements.length < 1) return '';
     let queryString = queryElements[0].name;
     for (let i = 1; i < queryElements.length; i++) {
-        if (queryElements[i].type !== 'symbol' || queryElements[i - 1].type !== 'symbol') {
+        if (
+            (queryElements[i].type !== queryElements[i - 1].type)
+            || (queryElements[i].type !== T_SYMBOL && queryElements[i].type !== T_NUMBER)
+            || (queryElements[i - 1].type !== T_SYMBOL && queryElements[i - 1].type !== T_NUMBER)
+        ) {
             queryString += ' ';
         }
         queryString += queryElements[i].name;


### PR DESCRIPTION
Fixes #20 by adding the 'number' type to blocks. In turn this means built text query now displays symbols and numbers with a space between them for improved readability.